### PR TITLE
feat: additional GPOS lookups parsers

### DIFF
--- a/src/tables/gpos.js
+++ b/src/tables/gpos.js
@@ -102,7 +102,7 @@ subtableParsers[4] = function parseLookup4() {
 };
 
 subtableParsers[5] = function parseLookup5() { return { error: 'GPOS Lookup 5 not supported' }; };
-subtableParsers[6] = function parseLookup5() { return { error: 'GPOS Lookup 6 not supported' }; };
+subtableParsers[6] = function parseLookup6() { return { error: 'GPOS Lookup 6 not supported' }; };
 subtableParsers[7] = function parseLookup7() { return { error: 'GPOS Lookup 7 not supported' }; };
 subtableParsers[8] = function parseLookup8() { return { error: 'GPOS Lookup 8 not supported' }; };
 

--- a/src/tables/gpos.js
+++ b/src/tables/gpos.js
@@ -77,12 +77,43 @@ subtableParsers[2] = function parseLookup2() {
 };
 
 subtableParsers[3] = function parseLookup3() { return { error: 'GPOS Lookup 3 not supported' }; };
-subtableParsers[4] = function parseLookup4() { return { error: 'GPOS Lookup 4 not supported' }; };
+
+// https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-4-mark-to-base-attachment-positioning-subtable
+subtableParsers[4] = function parseLookup4() {
+    const start = this.offset + this.relativeOffset;
+    const posFormat = this.parseUShort();
+    check.assert(posFormat === 1, '0x' + start.toString(16) + ': GPOS lookup type 4 format must be 1.');
+    const markCoverage = this.parsePointer(Parser.coverage);
+    const baseCoverage = this.parsePointer(Parser.coverage);
+    const markClassCount = this.parseUShort();
+    const markArray = this.parsePointer(function() {
+        return this.parseMarkArray();
+    });
+    const baseArray = this.parsePointer(function() {
+        return this.parseBaseArray(markClassCount);
+    });
+    return {
+        posFormat,
+        markCoverage,
+        baseCoverage,
+        markArray,
+        baseArray
+    };
+};
+
 subtableParsers[5] = function parseLookup5() { return { error: 'GPOS Lookup 5 not supported' }; };
-subtableParsers[6] = function parseLookup6() { return { error: 'GPOS Lookup 6 not supported' }; };
+subtableParsers[6] = function parseLookup5() { return { error: 'GPOS Lookup 6 not supported' }; };
 subtableParsers[7] = function parseLookup7() { return { error: 'GPOS Lookup 7 not supported' }; };
 subtableParsers[8] = function parseLookup8() { return { error: 'GPOS Lookup 8 not supported' }; };
-subtableParsers[9] = function parseLookup9() { return { error: 'GPOS Lookup 9 not supported' }; };
+
+// https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-9-extension-positioning
+subtableParsers[9] = function parseLookup9() {
+    const start = this.offset + this.relativeOffset;
+    const posFormat = this.parseUShort();
+    check.assert(posFormat === 1, '0x' + start.toString(16) + ': GPOS lookup type 9 format must be 1.');
+    const extensionLookupType = this.parseUShort();
+    return this.parsePointer32(subtableParsers[extensionLookupType]);
+};
 
 // https://docs.microsoft.com/en-us/typography/opentype/spec/gpos
 function parseGposTable(data, start) {

--- a/test/parse.js
+++ b/test/parse.js
@@ -106,6 +106,141 @@ describe('parse.js', function() {
         });
     });
 
+    describe('parseMarkArray', function() {
+        it('should parse a Mark Array table', function() {
+            const data = '0003 ' + // marksCount
+            ' 0000  000E ' + // mark1 class and its anchor offset
+            ' 0001  001A ' + // mark2 class and its anchor offset
+            ' 0000  0014 ' + // mark3 class and its anchor offset
+            ' 0001 00BD 012D ' +   
+            ' 0001 00DD 012E ' +
+            ' 0002 00DF FED1 0001';
+
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseMarkArray(), [{
+                class: 0,
+                attachmentPoint: {
+                    format: 1,
+                    xCoordinate: 189,
+                    yCoordinate: 301
+                }
+            }, {
+                class: 1,
+                attachmentPoint: {
+                    format: 2,
+                    xCoordinate: 223,
+                    yCoordinate: -303,
+                    anchorPoint: 1
+                }
+            },{
+                class: 0,
+                attachmentPoint: {
+                    format: 1,
+                    xCoordinate: 221,
+                    yCoordinate: 302,
+
+                }
+            }]);
+
+            assert.equal(p.relativeOffset, 14);
+        });
+    });
+
+    describe('parseBaseArray', function() {
+        it('should parse a Base Array table', function() {
+            const data = '0002 ' + // baseCount
+            ' 000E 0014 001E' + // baseRecord1 anchor offsets foreach class anchor point
+            ' 0014 000E 001E' + // baseRecord2 anchor offsets foreach class anchor point
+            ' 0001 00BD 012D ' +    // 
+            ' 0003 00BD 012D 0000 0000 ' +
+            ' 0002 00DF FED1 0001';
+
+           
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseBaseArray(3), [
+                [
+                    {
+                        format: 1,
+                        xCoordinate: 189,
+                        yCoordinate: 301
+                    },
+                    {
+                        format: 3,
+                        xCoordinate: 189,
+                        yCoordinate: 301,
+                        xDevice: 0,
+                        yDevice: 0
+                    },
+                    {
+                        format: 2,
+                        xCoordinate: 223,
+                        yCoordinate: -303,
+                        anchorPoint: 1
+                    }
+                ],
+                [
+                    
+                    {
+                        format: 3,
+                        xCoordinate: 189,
+                        yCoordinate: 301,
+                        xDevice: 0,
+                        yDevice: 0
+                    },
+                    {
+                        format: 1,
+                        xCoordinate: 189,
+                        yCoordinate: 301
+                    },
+                    {
+                        format: 2,
+                        xCoordinate: 223,
+                        yCoordinate: -303,
+                        anchorPoint: 1
+                    }
+                ]
+            ]);
+
+            assert.equal(p.relativeOffset, 14);
+
+        });
+    });
+
+    describe('parseAnchorPoint', function() {
+        it('should parse a AnchorTableFormat1 table', function() {
+            const data =' 0001 00BD 012D';
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseAnchorPoint(), {
+                format: 1,
+                xCoordinate: 189,
+                yCoordinate: 301,
+            });
+        });
+
+        it('should parse a AnchorTableFormat2 table', function() {
+            const data =' 0002 00DF FED1 0003';
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseAnchorPoint(), {
+                format: 2,
+                xCoordinate: 223,
+                yCoordinate: -303,
+                anchorPoint: 3
+            });
+        });
+
+        it('should parse a AnchorTableFormat3 table', function() {
+            const data =' 0003 00BD 012D 0000 0000';
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseAnchorPoint(), {
+                format: 3,
+                xCoordinate: 189,
+                yCoordinate: 301,
+                xDevice: 0,
+                yDevice: 0
+            });
+        });
+    });
+
     describe('parseCoverage', function() {
         it('should parse a CoverageFormat1 table', function() {
             // https://www.microsoft.com/typography/OTSPEC/chapter2.htm Example 5

--- a/test/tables/gpos.js
+++ b/test/tables/gpos.js
@@ -138,4 +138,204 @@ describe('tables/gpos.js', function() {
             ]
         });
     });
+
+    //// Lookup type 4 ////////////////////////////////////////////////////////
+    it('can parse lookup4 MarkBasePosFormat1', function() {
+
+        const data = 
+            ` 0001` + // MarkMarkPosFormat1
+            ` 000C` + // markCoverageOffset
+            ` 0016` + // baseCoverageOffset
+            ` 0002` + // markClassCount
+            ` 001C` + // markArrayOffset
+            ` 0038` + // baseArrayOffset
+            ` 0002 0001 0045 0046 0000` + 
+            ` 0001 0001 0047` +
+            ` 0002  0000  000A   0001  0016  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1` + 
+            ` 0001    0006 000C  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1` + 
+            ``;
+
+        const expectedResult = {
+            posFormat: 1,
+            markCoverage: {
+                format: 2,
+                ranges: [
+                    { start: 0x45, end: 0x46, index: 0 }
+                ]
+            },
+            baseCoverage: {
+                glyphs: [71],
+                format: 1
+            },
+            markArray: [{
+                class: 0,
+                attachmentPoint: {
+                    format: 1,
+                    xCoordinate: 189,
+                    yCoordinate: 301
+                }
+            }, {
+                class: 1,
+                attachmentPoint: {
+                    format: 1,
+                    xCoordinate: 223,
+                    yCoordinate: -303
+                }
+            }],
+            baseArray: [
+                [{
+                    format: 1,
+                    xCoordinate: 189,
+                    yCoordinate: 301
+                }, 
+                {
+                    format: 1,
+                    xCoordinate: 221,
+                    yCoordinate: 302
+                }]
+            ]
+        };
+
+        assert.deepEqual(parseLookup(4, data), expectedResult);
+    });
+
+    //// Lookup type 9 ////////////////////////////////////////////////////////
+    describe('lookup9 ExtensionPosFormat1', function() {
+
+        it('should return a message for unsupported lookup type format', function() {
+            const UnsupportedLookupTypeData = '0001';
+            const data = 
+                ` 0001` +
+                ` 0006` + // UNSUPPORTED lookup type extensionLookupType 
+                ` 00000008` + // extensionLookupTableOffset
+                ` ${UnsupportedLookupTypeData}` +
+                ``;
+
+            assert.deepEqual(parseLookup(9, data), { error: 'GPOS Lookup 6 not supported' });
+        });
+
+        it('can parse lookup1 extension table', function() {
+
+            const SinglePosFormat1data = '0001 0008 0002   FFB0 0002 0001   01B3 01BC 0000';
+            const data = 
+                ` 0001` +
+                ` 0001` + // extensionLookupType
+                ` 00000008` + // extensionLookupTableOffset
+                ` ${SinglePosFormat1data}` +
+                ``;
+
+            const expectedResult = {
+                posFormat: 1,
+                coverage: {
+                    format: 2,
+                    ranges: [{ start: 0x1b3, end: 0x1bc, index: 0 }]
+                },
+                value: { yPlacement: -80 }
+            };
+
+            assert.deepEqual(parseLookup(9, data), expectedResult);
+        }); 
+        
+        it('can parse lookup2 extension table', function() {
+
+            const lookup2Data = '0002 0018 0004 0000 0022 0032 0002 0002 0000 0000 0000 FFCE   0001 0003 0046 0047 0049   0002 0002 0046 0047 0001 0049 0049 0001   0002 0001 006A 006B 0001';
+            const data = 
+                ` 0001` +
+                ` 0002` + // extensionLookupType
+                ` 00000008` + // extensionLookupTableOffset
+                ` ${lookup2Data}` +
+                ``;
+
+            const expectedResult = {
+                posFormat: 2,
+                coverage: {
+                    format: 1,
+                    glyphs: [0x46, 0x47, 0x49]
+                },
+                valueFormat1: 4,
+                valueFormat2: 0,
+                classDef1: {
+                    format: 2,
+                    ranges: [
+                        { start: 0x46, end: 0x47, classId: 1 },
+                        { start: 0x49, end: 0x49, classId: 1 }
+                    ]
+                },
+                classDef2: {
+                    format: 2,
+                    ranges: [
+                        { start: 0x6a, end: 0x6b, classId: 1 }
+                    ]
+                },
+                class1Count: 2,
+                class2Count: 2,
+                classRecords: [
+                    [
+                        { value1: { xAdvance: 0 }, value2: undefined },
+                        { value1: { xAdvance: 0 }, value2: undefined }
+                    ],
+                    [
+                        { value1: { xAdvance: 0 }, value2: undefined },
+                        { value1: { xAdvance: -50 }, value2: undefined }
+                    ]
+                ]
+            };
+
+            assert.deepEqual(parseLookup(9, data), expectedResult);
+        }); 
+
+        it('can parse lookup4 extension table', function() {
+
+            const MarkBasePosFormat1 = ' 0001 000C 0016 0002 001C 0038 0002 0001 0045 0046 0000 0001 0001 0047 0002  0000  000A   0001  0016  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1 0001    0006 000C  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1';
+            const data = 
+                ` 0001` +
+                ` 0004` + // extensionLookupType
+                ` 00000008` + // extensionLookupTableOffset
+                ` ${MarkBasePosFormat1}` +
+                ``;
+
+                const expectedResult = {
+                    posFormat: 1,
+                    markCoverage: {
+                        format: 2,
+                        ranges: [
+                            { start: 0x45, end: 0x46, index: 0 }
+                        ]
+                    },
+                    baseCoverage: {
+                        glyphs: [71],
+                        format: 1
+                    },
+                    markArray: [{
+                        class: 0,
+                        attachmentPoint: {
+                            format: 1,
+                            xCoordinate: 189,
+                            yCoordinate: 301
+                        }
+                    }, {
+                        class: 1,
+                        attachmentPoint: {
+                            format: 1,
+                            xCoordinate: 223,
+                            yCoordinate: -303
+                        }
+                    }],
+                    baseArray: [ 
+                        [{
+                            format: 1,
+                            xCoordinate: 189,
+                            yCoordinate: 301
+                        }, {
+                            format: 1,
+                            xCoordinate: 221,
+                            yCoordinate: 302
+                        }]
+                    ]
+                };
+
+            assert.deepEqual(parseLookup(9, data), expectedResult);
+
+        });
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

feat: additional GPOS lookups parsers

- added Lookup Type 4 for MarkBasePosFormat1 support
- added Lookup Type 9 support (parsing any supported lookup tables of other type)
- tests coverage

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We needed to add support for thai and mandarin fonts. 
Lack of support for these lookups was affecting invalid glyphs positioning.
